### PR TITLE
Removed support for Node 12 in CI

### DIFF
--- a/.github/workflows/check-web-code.yml
+++ b/.github/workflows/check-web-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.5.0


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in `docs/` was updated, if applicable
- [ ] I have tested all changes

Node 12 is EOL as of 30/04/2022.